### PR TITLE
[#71] fix : 다른 페이지 이동 후 displaytext -1로 보이는 문제 해결

### DIFF
--- a/src/pages/item/create/components/PriceField/PriceField.tsx
+++ b/src/pages/item/create/components/PriceField/PriceField.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 import { useRecoilState } from 'recoil'
 import {
   InputFieldWrapper,
@@ -68,6 +68,12 @@ const PriceField = () => {
       })
     }
   }
+
+  useEffect(() => {
+    if (itemInfo.price === -1) {
+      setPriceUnknown(true)
+    }
+  }, [itemInfo.price])
 
   return (
     <PriceFieldWrapper>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#71 -> develop

### 변경 사항
다른 페이지 이동 후 displaytext -1로 보이는 문제 해결

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.