### PR TITLE
feat:[브릿지] 네이티브와 웹뷰 통신을 위한 브릿지 코드 설계 및 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import storage from './utils/storage'
 import SelectItemOrPhoto from './components/SelectItemOrPhoto'
 
 import Loading from './components/Loading'
-import { bridgeProxyAdapter } from './utils/bridge/adapter'
+import { bridgeProxyAdapter } from './utils/bridge'
 
 bridgeProxyAdapter()
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ import storage from './utils/storage'
 import SelectItemOrPhoto from './components/SelectItemOrPhoto'
 
 import Loading from './components/Loading'
+import { bridgeProxyAdapter } from './utils/bridge/adapter'
+
+bridgeProxyAdapter()
+
 const loading = <Loading />
 
 // 에러 페이지

--- a/src/utils/bridge/adapter/bridgeAdapter.spec.ts
+++ b/src/utils/bridge/adapter/bridgeAdapter.spec.ts
@@ -1,0 +1,26 @@
+import { bridgeElementsCreator, bridgeProxyAdapter } from './index'
+
+const initializeBridgeController = () => {
+  const { bridgeController, bridgeServiceManager } = bridgeElementsCreator()
+  bridgeProxyAdapter()
+
+  return { bridgeController, bridgeServiceManager }
+}
+
+describe('On Application Mount', () => {
+  describe('bridgeElementCreator', () => {
+    it('bridgeElementCreator는 Bridge 구성 요소를 생성한다', () => {
+      const { bridgeController, bridgeServiceManager } = initializeBridgeController()
+
+      expect(bridgeController).toBeDefined()
+      expect(bridgeServiceManager).toBeDefined()
+    })
+  })
+
+  describe('BridgeProxyAdapter', () => {
+    it('bridgeAdapter는 전역객체에 bridgeController를 바인딩한다.', () => {
+      const { bridgeController } = initializeBridgeController()
+      expect(window.sendToWebview).toBe(bridgeController.receiveMessage)
+    })
+  })
+})

--- a/src/utils/bridge/adapter/index.ts
+++ b/src/utils/bridge/adapter/index.ts
@@ -1,0 +1,17 @@
+import { BridgeController } from '../controller'
+import BridgeServiceManager from '../service/manager'
+
+type BridgeProxyAdapterProps = {
+  callback?: () => any
+}
+
+export const bridgeProxyAdapter = (props?: BridgeProxyAdapterProps) => {
+  const bridgeServiceManager = new BridgeServiceManager()
+  const bridgeController = new BridgeController(bridgeServiceManager)
+  console.log(bridgeController)
+
+  // android, ios 에서 동일한 인터페이스로 메세지를 전송해줄 수 있도록 설정
+  window.sendToWebview = bridgeController.receiveMessage
+
+  return props?.callback?.()
+}

--- a/src/utils/bridge/adapter/index.ts
+++ b/src/utils/bridge/adapter/index.ts
@@ -1,17 +1,25 @@
 import { BridgeController } from '../controller'
 import BridgeServiceManager from '../service/manager'
 
-type BridgeProxyAdapterProps = {
+export const bridgeElementsCreator = () => {
+  const bridgeServiceManager = new BridgeServiceManager()
+  const bridgeController = new BridgeController(bridgeServiceManager)
+
+  return {
+    bridgeController,
+    bridgeServiceManager,
+  }
+}
+
+export const bridgeElements = bridgeElementsCreator()
+
+export type BridgeProxyAdapterProps = {
   callback?: () => any
 }
 
 export const bridgeProxyAdapter = (props?: BridgeProxyAdapterProps) => {
-  const bridgeServiceManager = new BridgeServiceManager()
-  const bridgeController = new BridgeController(bridgeServiceManager)
-  console.log(bridgeController)
-
   // android, ios 에서 동일한 인터페이스로 메세지를 전송해줄 수 있도록 설정
-  window.sendToWebview = bridgeController.receiveMessage
+  window.sendToWebview = bridgeElements.bridgeController.receiveMessage
 
   return props?.callback?.()
 }

--- a/src/utils/bridge/controller/BridgeController.spec.ts
+++ b/src/utils/bridge/controller/BridgeController.spec.ts
@@ -1,0 +1,38 @@
+import BridgeController from './index'
+import BridgeServiceManager from '../service/manager'
+
+const initBridgeController = () => {
+  return new BridgeController(new BridgeServiceManager())
+}
+
+jest.mock('../service/manager')
+
+const TEST_SUBSCRIBER = () => {
+  return 'test'
+}
+
+describe('Bridge Controller', () => {
+  describe('subscribe 호출 시', () => {
+    it('unsubscribe, requestMessage 함수가 반환된다.', () => {
+      const bridgeController = initBridgeController()
+
+      const { unsubscribe, requestMessage } = bridgeController.subscribe(
+        'testBridgeService',
+        TEST_SUBSCRIBER,
+      )
+
+      expect(unsubscribe).not.toBe(undefined || null)
+      expect(requestMessage).not.toBe(undefined || null)
+    })
+  })
+
+  it('bridgeController observer에 등록된다.', () => {
+    const bridgeController = initBridgeController()
+
+    bridgeController.subscribe('testBridgeService', TEST_SUBSCRIBER)
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(bridgeController.observers.some((value) => value.observer === TEST_SUBSCRIBER))
+  })
+})

--- a/src/utils/bridge/controller/index.ts
+++ b/src/utils/bridge/controller/index.ts
@@ -1,0 +1,89 @@
+import {
+  BridgeMessage,
+  BridgeMessageHeader,
+  BridgeMessageType,
+  BridgeServiceManager,
+} from '../service'
+import { generateRandomHash } from '../../hash'
+import {
+  BridgeServiceKeys,
+  BridgeServiceObserver,
+  BridgeServices,
+  MappedObserver,
+  ReceivePayloadOf,
+  RequestPayloadOf,
+} from './types'
+
+export class BridgeController {
+  private serviceManager = BridgeServiceManager
+  private observers: MappedObserver<BridgeServiceKeys>[] = []
+
+  public subscribe<S extends keyof BridgeServices>(
+    serviceName: S,
+    observer: BridgeServiceObserver<RequestPayloadOf<S>, ReceivePayloadOf<S>>,
+  ) {
+    const service = this.serviceManager.getService(serviceName)
+    const ObserverCode = generateRandomHash()
+
+    const mapped: MappedObserver<S> = {
+      code: ObserverCode,
+      observer: observer.bind(service),
+      service,
+    }
+
+    this.observers.push(mapped)
+
+    return {
+      requestMessage: this.createRequestMessage(ObserverCode, service),
+      unsubscribe: this.createObserverUnsubscriber(mapped),
+    }
+  }
+
+  public receiveMessage<TPayload = unknown>(message: BridgeMessage<TPayload>) {
+    // code에 따라 특정 서비스를 호출해서 해당 서비스의 receiveMessage를 실행해야 한다.
+    this.observers.forEach((obs) => {
+      if (obs.code === message.header.code) {
+        obs.service.receiveMessage(message.header, message.payload)
+      }
+    })
+
+    this.notify(message)
+  }
+
+  private createRequestMessage<S extends BridgeServiceKeys>(
+    code: BridgeMessageHeader['code'],
+    service: BridgeServices[S],
+  ) {
+    return (type: BridgeMessageType, payload: RequestPayloadOf<S>) => {
+      const header: BridgeMessageHeader = {
+        type,
+        code,
+      }
+
+      service.requestMessage(header, payload)
+    }
+  }
+
+  private createObserverUnsubscriber = (obs: MappedObserver<BridgeServiceKeys>) => {
+    return () => {
+      const targetIndex = this.observers.indexOf(obs)
+      this.observers = this.observers.filter((obs, idx) => idx !== targetIndex)
+    }
+  }
+
+  private notify = <TPayload = unknown>(message: BridgeMessage<TPayload>) => {
+    this.observers.forEach((obs) => {
+      if (obs.code === message.header.code) {
+        obs.observer.call(obs.service)
+      }
+    })
+  }
+}
+
+const bridgeController = new BridgeController()
+
+// android, ios 에서 동일한 인터페이스로 메세지를 전송해줄 수 있도록 설정
+window.AndroidBridge.sendToWebview = bridgeController.receiveMessage
+window.webkit.messageHandlers.IOSBridge.sendToWebview = bridgeController.receiveMessage
+
+export default bridgeController

--- a/src/utils/bridge/controller/types.ts
+++ b/src/utils/bridge/controller/types.ts
@@ -1,12 +1,4 @@
-import {
-  BridgeMessage,
-  BridgeMessageHeader,
-  BridgeMessagePayload,
-  BridgeMessageType,
-  BridgeService,
-  BridgeServiceManager,
-} from '../service'
-import { generateRandomHash } from '../../hash'
+import { BridgeMessage, BridgeService } from '../service'
 import { ServiceList } from '../service/list'
 
 export type BridgeServices = typeof ServiceList

--- a/src/utils/bridge/controller/types.ts
+++ b/src/utils/bridge/controller/types.ts
@@ -1,0 +1,32 @@
+import {
+  BridgeMessage,
+  BridgeMessageHeader,
+  BridgeMessagePayload,
+  BridgeMessageType,
+  BridgeService,
+  BridgeServiceManager,
+} from '../service'
+import { generateRandomHash } from '../../hash'
+import { ServiceList } from '../service/list'
+
+export type BridgeServices = typeof ServiceList
+export type BridgeServiceKeys = keyof BridgeServices
+
+export type BridgeServiceObserver<
+  TReqPayload = unknown,
+  TResPayload = unknown,
+  S extends BridgeService<TReqPayload, TResPayload> = BridgeService<TReqPayload, TResPayload>,
+> = (this: S, message?: BridgeMessage<TReqPayload | TResPayload>) => void
+
+export type RequestPayloadOf<S extends keyof BridgeServices> = Parameters<
+  BridgeServices[S]['requestMessage']
+>[1]
+export type ReceivePayloadOf<S extends keyof BridgeServices> = Parameters<
+  BridgeServices[S]['receiveMessage']
+>[1]
+
+export interface MappedObserver<S extends BridgeServiceKeys> {
+  code: string
+  observer: BridgeServiceObserver<RequestPayloadOf<S>, ReceivePayloadOf<S>>
+  service: BridgeServices[S]
+}

--- a/src/utils/bridge/index.ts
+++ b/src/utils/bridge/index.ts
@@ -1,0 +1,4 @@
+export * from './service'
+export * from './adapter'
+export * from './shared'
+export * from './controller'

--- a/src/utils/bridge/service/index.ts
+++ b/src/utils/bridge/service/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export { bridgeServiceManager as BridgeServiceManager } from './manager'

--- a/src/utils/bridge/service/index.ts
+++ b/src/utils/bridge/service/index.ts
@@ -1,2 +1,2 @@
 export * from './types'
-export { bridgeServiceManager as BridgeServiceManager } from './manager'
+export * from './manager'

--- a/src/utils/bridge/service/list/TestService.ts
+++ b/src/utils/bridge/service/list/TestService.ts
@@ -1,0 +1,30 @@
+import {
+  BridgeMessage,
+  BridgeMessageHeader,
+  BridgeMessagePayload,
+  BridgeServiceAbstraction,
+} from '../types'
+
+type TestServiceRequestPayload = { req: string }
+type TestServiceResponsePayload = { res: string }
+class TestBridgeService extends BridgeServiceAbstraction<
+  TestServiceRequestPayload,
+  TestServiceResponsePayload
+> {
+  receiveMessage(
+    header: BridgeMessageHeader,
+    payload: BridgeMessagePayload<TestServiceResponsePayload>,
+  ): void {
+    console.log('receive')
+    console.log(header, payload)
+  }
+
+  createMessage(
+    header: BridgeMessageHeader,
+    payload: BridgeMessagePayload<TestServiceRequestPayload>,
+  ): BridgeMessage<TestServiceRequestPayload> {
+    return { header, payload }
+  }
+}
+
+export default new TestBridgeService()

--- a/src/utils/bridge/service/list/index.ts
+++ b/src/utils/bridge/service/list/index.ts
@@ -1,0 +1,5 @@
+import testBridgeService from './TestService'
+
+export const ServiceList = {
+  testBridgeService,
+}

--- a/src/utils/bridge/service/manager/index.ts
+++ b/src/utils/bridge/service/manager/index.ts
@@ -1,0 +1,21 @@
+import testBridgeService from '../list/TestService'
+import { ServiceList } from '../list'
+
+class BridgeServiceManager {
+  readonly bridgeServices = ServiceList
+  readonly bridgeServiceKeys = Object.keys(ServiceList) as (keyof typeof ServiceList)[]
+
+  getService<TReqPayload, TResPayload>(serviceName: keyof typeof this.bridgeServices) {
+    return this.bridgeServices[serviceName]
+  }
+
+  getServiceKeys() {
+    return this.bridgeServiceKeys
+  }
+
+  getServiceList() {
+    return this.bridgeServices
+  }
+}
+
+export const bridgeServiceManager = new BridgeServiceManager()

--- a/src/utils/bridge/service/manager/index.ts
+++ b/src/utils/bridge/service/manager/index.ts
@@ -18,4 +18,4 @@ class BridgeServiceManager {
   }
 }
 
-export const bridgeServiceManager = new BridgeServiceManager()
+export default BridgeServiceManager

--- a/src/utils/bridge/service/types.ts
+++ b/src/utils/bridge/service/types.ts
@@ -1,0 +1,43 @@
+import { sendMessageToNative } from '../shared'
+
+export type BridgeMessageType = 'Permission' | 'Normal'
+
+export type BridgeMessageHeader = {
+  type: BridgeMessageType
+  code: string
+}
+export type BridgeMessagePayload<T = unknown> = T
+
+export interface BridgeMessage<TPayload> {
+  header: BridgeMessageHeader
+  payload: BridgeMessagePayload<TPayload>
+}
+
+export type BridgeTransactionFunction<TPayload> = (
+  header: BridgeMessageHeader,
+  payload: BridgeMessagePayload<TPayload>,
+) => void
+
+export interface BridgeService<TRequestPayload = unknown, TReceivePayload = unknown> {
+  requestMessage: BridgeTransactionFunction<TRequestPayload>
+  receiveMessage: BridgeTransactionFunction<TReceivePayload>
+}
+
+export abstract class BridgeServiceAbstraction<RequestPayload, ReceivePayload>
+  implements BridgeService<RequestPayload, ReceivePayload>
+{
+  requestMessage(header: BridgeMessageHeader, payload: BridgeMessagePayload<RequestPayload>): void {
+    const message = this.createMessage(header, payload)
+    sendMessageToNative(message)
+  }
+
+  abstract createMessage(
+    header: BridgeMessageHeader,
+    payload: BridgeMessagePayload<RequestPayload>,
+  ): BridgeMessage<RequestPayload>
+
+  abstract receiveMessage(
+    header: BridgeMessageHeader,
+    payload: BridgeMessagePayload<ReceivePayload>,
+  ): void
+}

--- a/src/utils/bridge/shared/global.d.ts
+++ b/src/utils/bridge/shared/global.d.ts
@@ -4,15 +4,14 @@ declare global {
   interface Window {
     AndroidBridge: {
       sendToNative: (message: string) => void
-      sendToWebview: (message: BridgeMessage<any>) => void
     }
     webkit: {
       messageHandlers: {
         IOSBridge: {
           sendToNative: (message: string) => void
-          sendToWebview: (message: BridgeMessage<any>) => void
         }
       }
     }
+    sendToWebview: (message: string) => void
   }
 }

--- a/src/utils/bridge/shared/global.d.ts
+++ b/src/utils/bridge/shared/global.d.ts
@@ -1,0 +1,18 @@
+import { BridgeMessage } from '../service'
+
+declare global {
+  interface Window {
+    AndroidBridge: {
+      sendToNative: (message: string) => void
+      sendToWebview: (message: BridgeMessage<any>) => void
+    }
+    webkit: {
+      messageHandlers: {
+        IOSBridge: {
+          sendToNative: (message: string) => void
+          sendToWebview: (message: BridgeMessage<any>) => void
+        }
+      }
+    }
+  }
+}

--- a/src/utils/bridge/shared/index.ts
+++ b/src/utils/bridge/shared/index.ts
@@ -1,0 +1,13 @@
+import { BridgeMessage } from '../service'
+
+export const sendMessageToNative = (message: BridgeMessage<any>): void => {
+  const serialized = JSON.stringify(message)
+
+  if (window.AndroidBridge && window.AndroidBridge.sendToNative) {
+    window.AndroidBridge.sendToNative(serialized)
+  } else if (window.webkit.messageHandlers.IOSBridge) {
+    window.webkit.messageHandlers.IOSBridge.sendToNative(serialized)
+  } else {
+    throw new Error('WebView interface is not available.')
+  }
+}

--- a/src/utils/hash/index.ts
+++ b/src/utils/hash/index.ts
@@ -1,5 +1,17 @@
-import crypto from 'crypto'
+const getRandomChar = (): string => {
+  const charType = Math.floor(Math.random() * 3)
+  switch (charType) {
+    case 0: // 대문자
+      return String.fromCharCode(Math.floor(Math.random() * 26) + 65)
+    case 1: // 소문자
+      return String.fromCharCode(Math.floor(Math.random() * 26) + 97)
+    case 2: // 숫자
+      return String.fromCharCode(Math.floor(Math.random() * 10) + 48)
+    default:
+      return ''
+  }
+}
 
 export const generateRandomHash = (): string => {
-  return crypto.randomBytes(32).toString('hex')
+  return Array.from({ length: 64 }, getRandomChar).join('')
 }

--- a/src/utils/hash/index.ts
+++ b/src/utils/hash/index.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto'
+
+export const generateRandomHash = (): string => {
+  return crypto.randomBytes(32).toString('hex')
+}

--- a/src/utils/userAgent/index.ts
+++ b/src/utils/userAgent/index.ts
@@ -1,0 +1,4 @@
+export * from './utils'
+export * from './types'
+
+export * as Default from './utils'

--- a/src/utils/userAgent/types.ts
+++ b/src/utils/userAgent/types.ts
@@ -1,0 +1,1 @@
+export type UserPlatform = 'Android' | 'IOS' | 'PC'

--- a/src/utils/userAgent/utils.ts
+++ b/src/utils/userAgent/utils.ts
@@ -1,0 +1,21 @@
+import { UserPlatform } from './types'
+
+const IOS = 'iPhone|iPad|iPod|Mac'
+const ANDROID = 'Android'
+
+const getUserAgent = () => {
+  return window.navigator.userAgent
+}
+export const getWebviewPlatform = (): UserPlatform => {
+  const userAgent = getUserAgent()
+
+  if (/IOS/.test(userAgent)) {
+    return 'IOS'
+  }
+
+  if (/ANDROID/.test(userAgent)) {
+    return 'Android'
+  }
+
+  return 'PC'
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-기능 추가

### 변경 사항
웹뷰 통신 로직 구현


메세지 송 수신 형태 :

{
  header:{
    type :합의 하에 정의된 문자열을 사용 ex: 'permission', normal' 등, string literal 타입입니다.
    code : 웹뷰에서 메세지 전송 시 랜덤하게 생성되는 해쉬값으로, 클라이언트 측에서 옵저버 패턴을 통해 리액트와 연동하는 목적으로 사용됩니 
                  다. 네이티브에서 메세지에 답신할 때 송신순간에 받은 코드와 정확하게 동일한 값을 전달해야 합니다. 'string' 입니다.
  }
  payload : 어떤 타입이던 올 수 있으나 객체(MAP) 형태로 보내는 것으로 합의하는 것이 좋습니다.
  
}

메세지 송 수신 시 JSON으로 파싱해서 전송해야 합니다. 반대로 수신할 때 deserializing 하는 로직또한 작성되어야 합니다.(클라이언트는 대응 완료, 네이티브 측 필요한 것으로 추정)


declare global {
  interface Window {
    AndroidBridge: {
      sendToNative: (message: string) => void
    }
    webkit: {
      messageHandlers: {
        IOSBridge: {
          sendToNative: (message: string) => void
        }
      }
    }
    sendToWebview: (message: string) => void
  }
}

IOS에서는 IOSBridge 객체 내부에 sendToNative 메서드를 구현해야 하며 웹뷰 로딩 이전 인터페이스 설정을 진행해야 합니다.
Android는 AndroidBridge객체를 생성하여 동일하게 작업합니다.

메세지 전송시 네이티브 측에서는 항상 window.sendToWebviw 함수로 보내면 됩니다.

클라이언트 측에서는 subscribe가 반환하는 requestMessage() 메서드를 통해 메세지 전송 타이밍을 조절할 수 있습니다.
리액트에서 사용 시 반드시 언마운트 시 unsubscribe가 진행되어야 합니다. (관련 훅 작성 예정)

### 테스트 결과

일부 테스트 코드 작성, 정확한 테스트를 위해선 네이티브쪽 코드 대응이 필요.
