### PR TITLE
[#327] fix : notification api prod로 변경

### DIFF
--- a/src/apis/notification/notificationService.ts
+++ b/src/apis/notification/notificationService.ts
@@ -11,7 +11,7 @@ export default class NotificationService {
   }
 
   async getNotificationReadStatus() {
-    const data: ResponseType<INotificationRead> = await dev.get(`${this.notificationUrl}/check`)
+    const data: ResponseType<INotificationRead> = await request.get(`${this.notificationUrl}/check`)
     return data.result
   }
 

--- a/src/pages/notifications/index.tsx
+++ b/src/pages/notifications/index.tsx
@@ -16,13 +16,12 @@ import { toast } from 'react-toastify'
 const Notifications = () => {
   const {
     getNotificationList,
-    getDevNotificationList,
+    // getDevNotificationList,
     deleteNotification: { mutate: mutateByDeleteSelected },
     deleteAllNotifications: { mutate: mutateByDeleteAll },
   } = useNotificationQuery()
-  const { data } = getDevNotificationList()
+  const { data } = getNotificationList()
   const notificationList = data?.pages[0].content
-  console.log('notificationList', notificationList)
   const [isEditMode, setIsEditMode] = useState<boolean>(false)
   const checkedList = useRecoilValue(deleteNotificationsState)
   const resetCheckedList = useResetRecoilState(deleteNotificationsState)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [] 기능 추가
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

ex) feat/login -> dev

### 변경 사항

ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
